### PR TITLE
AppName must be static

### DIFF
--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">PocketInvEditor</string>
     <string name="select_world">월드 선택</string>
     <string name="inventory">인벤토리</string>
     <string name="select_slot">인벤토리 슬롯을 선택하세요.</string>


### PR DESCRIPTION
Delete localizationable app_name to follow English app_name.
Currently app_name deleted in Korean strings only.
